### PR TITLE
Fix: make backup restore robust across app versions

### DIFF
--- a/app/src/main/java/com/maloy/muzza/db/MusicDatabase.kt
+++ b/app/src/main/java/com/maloy/muzza/db/MusicDatabase.kt
@@ -113,13 +113,16 @@ abstract class InternalDatabase : RoomDatabase() {
             name: String,
         ): RoomDatabase.Builder<InternalDatabase> =
             Room.databaseBuilder(context, InternalDatabase::class.java, name)
-                .addMigrations(
-                    MIGRATION_1_2,
-                    MIGRATION_19_20,
-                    MIGRATION_20_21,
-                    MIGRATION_21_22,
-                    MIGRATION_22_23,
-                )
+                // Only MIGRATION_1_2 is a hand-written migration with no auto-migration
+                // counterpart. Everything from v2 onwards is handled by the generated
+                // auto-migrations declared in @Database. Manually added migrations for
+                // 19->24 used to be listed here too, but Room lets a manually added
+                // migration override the auto-migration for the same version pair, and the
+                // hand-written 19->20 was incomplete (it only added `isVideoSong` and never
+                // performed the column deletions the real Migration19To20 does). That left
+                // stale columns behind and made restoring older backups fail schema
+                // validation. Relying solely on the compile-verified auto-migrations fixes it.
+                .addMigrations(MIGRATION_1_2)
 
         fun newInstance(context: Context): MusicDatabase =
             MusicDatabase(
@@ -449,33 +452,6 @@ class Migration18To19 : AutoMigrationSpec {
     }
 }
 
-/**
- * True if [column] already exists on [table]. Used to make additive migrations idempotent,
- * so restoring a backup (which may already contain the column, depending on the exact
- * migration path a previous app version took) never aborts with "duplicate column name".
- */
-private fun SupportSQLiteDatabase.hasColumn(table: String, column: String): Boolean =
-    query("PRAGMA table_info(`$table`)").use { cursor ->
-        val nameIndex = cursor.getColumnIndex("name")
-        if (nameIndex < 0) return false
-        while (cursor.moveToNext()) {
-            if (cursor.getString(nameIndex) == column) return true
-        }
-        false
-    }
-
-private fun SupportSQLiteDatabase.addColumnIfMissing(table: String, column: String, definition: String) {
-    if (!hasColumn(table, column)) {
-        execSQL("ALTER TABLE `$table` ADD COLUMN $column $definition")
-    }
-}
-
-val MIGRATION_19_20 = object : Migration(19, 20) {
-    override fun migrate(database: SupportSQLiteDatabase) {
-        database.addColumnIfMissing("song", "isVideoSong", "INTEGER NOT NULL DEFAULT 0")
-    }
-}
-
 @DeleteColumn.Entries(
     DeleteColumn(tableName = "song", columnName = "explicit"),
     DeleteColumn(tableName = "song", columnName = "year"),
@@ -489,41 +465,11 @@ val MIGRATION_19_20 = object : Migration(19, 20) {
 @DeleteTable(
     tableName = "playCount"
 )
-class Migration19To20: AutoMigrationSpec {
-    override fun onPostMigrate(db: SupportSQLiteDatabase) {
-        var columnExists = false
-        db.query("PRAGMA table_info(lyrics)").use { cursor ->
-            val nameIndex = cursor.getColumnIndex("name")
-            while (cursor.moveToNext()) {
-                if (cursor.getString(nameIndex) == "provider") {
-                    columnExists = true
-                    break
-                }
-            }
-        }
-        if (!columnExists) {
-            db.execSQL("ALTER TABLE lyrics ADD COLUMN provider TEXT NOT NULL DEFAULT 'Unknown'")
-        }
-    }
-}
-
-val MIGRATION_20_21 = object : Migration(20, 21) {
-    override fun migrate(database: SupportSQLiteDatabase) {
-        database.addColumnIfMissing("song", "explicit", "INTEGER NOT NULL DEFAULT 0")
-    }
-}
-
-val MIGRATION_21_22 = object : Migration(21, 22) {
-    override fun migrate(database: SupportSQLiteDatabase) {
-        database.addColumnIfMissing("artist", "isProfile", "INTEGER NOT NULL DEFAULT 0")
-    }
-}
-
-val MIGRATION_22_23 = object : Migration(22, 23) {
-    override fun migrate(database: SupportSQLiteDatabase) {
-        database.addColumnIfMissing("playlist", "description", "INTEGER NOT NULL DEFAULT 0")
-    }
-}
+// NOTE: `lyrics.provider` is intentionally NOT added here. Per the exported schemas it is
+// first introduced in version 21, so the auto-migration for 20 -> 21 adds it. Adding it here
+// (as a previous version did) makes the column exist prematurely and causes the 20 -> 21
+// migration to fail with "duplicate column name: provider" when migrating an older backup.
+class Migration19To20 : AutoMigrationSpec
 
 @DeleteColumn.Entries(
     DeleteColumn(tableName = "playlist", columnName = "playlistAuthors")

--- a/app/src/main/java/com/maloy/muzza/db/MusicDatabase.kt
+++ b/app/src/main/java/com/maloy/muzza/db/MusicDatabase.kt
@@ -102,14 +102,33 @@ abstract class InternalDatabase : RoomDatabase() {
     companion object {
         const val DB_NAME = "song.db"
 
+        /**
+         * Shared builder used both for the live database and for validating/migrating a
+         * restored backup. Keeping a single definition guarantees that a backup is migrated
+         * through exactly the same path the app itself uses, so any backup that a given app
+         * version can open in-place can also be restored by that version.
+         */
+        fun databaseBuilder(
+            context: Context,
+            name: String,
+        ): RoomDatabase.Builder<InternalDatabase> =
+            Room.databaseBuilder(context, InternalDatabase::class.java, name)
+                .addMigrations(
+                    MIGRATION_1_2,
+                    MIGRATION_19_20,
+                    MIGRATION_20_21,
+                    MIGRATION_21_22,
+                    MIGRATION_22_23,
+                )
+
         fun newInstance(context: Context): MusicDatabase =
             MusicDatabase(
-                delegate = Room.databaseBuilder(context, InternalDatabase::class.java, DB_NAME)
-                    .addMigrations(MIGRATION_1_2)
-                    .addMigrations(MIGRATION_19_20)
-                    .addMigrations(MIGRATION_20_21)
-                    .addMigrations(MIGRATION_21_22)
-                    .addMigrations(MIGRATION_22_23)
+                delegate = databaseBuilder(context, DB_NAME)
+                    // A backup created by a newer app version cannot be safely opened by an
+                    // older one. Rather than crash-looping on startup (forcing the user to
+                    // clear app data), reset gracefully. Restore itself refuses such backups
+                    // up-front, so this is only a last-resort safety net.
+                    .fallbackToDestructiveMigrationOnDowngrade(dropAllTables = true)
                     .build()
             )
     }
@@ -430,9 +449,30 @@ class Migration18To19 : AutoMigrationSpec {
     }
 }
 
+/**
+ * True if [column] already exists on [table]. Used to make additive migrations idempotent,
+ * so restoring a backup (which may already contain the column, depending on the exact
+ * migration path a previous app version took) never aborts with "duplicate column name".
+ */
+private fun SupportSQLiteDatabase.hasColumn(table: String, column: String): Boolean =
+    query("PRAGMA table_info(`$table`)").use { cursor ->
+        val nameIndex = cursor.getColumnIndex("name")
+        if (nameIndex < 0) return false
+        while (cursor.moveToNext()) {
+            if (cursor.getString(nameIndex) == column) return true
+        }
+        false
+    }
+
+private fun SupportSQLiteDatabase.addColumnIfMissing(table: String, column: String, definition: String) {
+    if (!hasColumn(table, column)) {
+        execSQL("ALTER TABLE `$table` ADD COLUMN $column $definition")
+    }
+}
+
 val MIGRATION_19_20 = object : Migration(19, 20) {
     override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("ALTER TABLE song ADD COLUMN isVideoSong INTEGER NOT NULL DEFAULT 0")
+        database.addColumnIfMissing("song", "isVideoSong", "INTEGER NOT NULL DEFAULT 0")
     }
 }
 
@@ -469,19 +509,19 @@ class Migration19To20: AutoMigrationSpec {
 
 val MIGRATION_20_21 = object : Migration(20, 21) {
     override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("ALTER TABLE song ADD COLUMN explicit INTEGER NOT NULL DEFAULT 0")
+        database.addColumnIfMissing("song", "explicit", "INTEGER NOT NULL DEFAULT 0")
     }
 }
 
 val MIGRATION_21_22 = object : Migration(21, 22) {
     override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("ALTER TABLE artist ADD COLUMN isProfile INTEGER NOT NULL DEFAULT 0")
+        database.addColumnIfMissing("artist", "isProfile", "INTEGER NOT NULL DEFAULT 0")
     }
 }
 
 val MIGRATION_22_23 = object : Migration(22, 23) {
     override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("ALTER TABLE playlist ADD COLUMN description INTEGER NOT NULL DEFAULT 0")
+        database.addColumnIfMissing("playlist", "description", "INTEGER NOT NULL DEFAULT 0")
     }
 }
 

--- a/app/src/main/java/com/maloy/muzza/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/java/com/maloy/muzza/viewmodels/BackupRestoreViewModel.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
 import androidx.lifecycle.ViewModel
+import androidx.room.RoomDatabase
 import com.maloy.muzza.MainActivity
 import com.maloy.muzza.R
 import com.maloy.muzza.db.InternalDatabase
@@ -19,6 +20,7 @@ import com.maloy.muzza.utils.reportException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.util.zip.ZipEntry
@@ -40,10 +42,15 @@ class BackupRestoreViewModel @Inject constructor(
                     runBlocking(Dispatchers.IO) {
                         database.checkpoint()
                     }
+                    val dbVersion = database.openHelper.writableDatabase.version
                     FileInputStream(database.openHelper.writableDatabase.path).use { inputStream ->
                         outputStream.putNextEntry(ZipEntry(InternalDatabase.DB_NAME))
                         inputStream.copyTo(outputStream)
                     }
+                    // Self-describing metadata so any future version can tell which schema this
+                    // backup was created with, and refuse it gracefully if it is too new.
+                    outputStream.putNextEntry(ZipEntry(METADATA_FILENAME))
+                    outputStream.write("$KEY_DB_VERSION=$dbVersion\n".toByteArray())
                 }
             }
         }.onSuccess {
@@ -56,41 +63,132 @@ class BackupRestoreViewModel @Inject constructor(
 
     fun restore(context: Context, uri: Uri) {
         runCatching {
-            context.applicationContext.contentResolver.openInputStream(uri)?.use {
-                it.zipInputStream().use { inputStream ->
-                    var entry = tryOrNull { inputStream.nextEntry }
-                    while (entry != null) {
-                        when (entry.name) {
-                            SETTINGS_FILENAME -> {
-                                (context.filesDir / "datastore" / SETTINGS_FILENAME).outputStream().use { outputStream ->
-                                    inputStream.copyTo(outputStream)
-                                }
-                            }
+            val tempDbFile = File(context.cacheDir, "restore_${System.currentTimeMillis()}.db")
+            var hasDb = false
+            var settingsBytes: ByteArray? = null
+            var backupDbVersion: Int? = null
 
-                            InternalDatabase.DB_NAME -> {
-                                runBlocking(Dispatchers.IO) {
-                                    database.checkpoint()
+            try {
+                // 1. Extract the archive to temporary storage without touching live data.
+                context.applicationContext.contentResolver.openInputStream(uri)?.use {
+                    it.zipInputStream().use { inputStream ->
+                        var entry = tryOrNull { inputStream.nextEntry }
+                        while (entry != null) {
+                            when (entry.name) {
+                                SETTINGS_FILENAME -> {
+                                    settingsBytes = inputStream.readBytes()
                                 }
-                                database.close()
-                                FileOutputStream(database.openHelper.writableDatabase.path).use { outputStream ->
-                                    inputStream.copyTo(outputStream)
+
+                                InternalDatabase.DB_NAME -> {
+                                    FileOutputStream(tempDbFile).use { output ->
+                                        inputStream.copyTo(output)
+                                    }
+                                    hasDb = true
+                                }
+
+                                METADATA_FILENAME -> {
+                                    backupDbVersion = parseDbVersion(inputStream.readBytes().decodeToString())
                                 }
                             }
+                            entry = tryOrNull { inputStream.nextEntry }
                         }
-                        entry = tryOrNull { inputStream.nextEntry }
                     }
                 }
+
+                // 2. Validate the database can actually be brought up to the current schema
+                //    BEFORE overwriting anything. If it can't, we abort and leave the app's
+                //    existing data intact instead of crash-looping on next launch.
+                if (hasDb) {
+                    val currentVersion = database.openHelper.readableDatabase.version
+                    if (backupDbVersion != null && backupDbVersion!! > currentVersion) {
+                        // A newer backup would require a schema downgrade, which is impossible.
+                        throw BackupNewerException()
+                    }
+                    migrateBackupDatabase(context, tempDbFile)
+                }
+
+                // 3. Everything validated -> commit the restore.
+                if (settingsBytes != null) {
+                    (context.filesDir / "datastore" / SETTINGS_FILENAME).outputStream().use { output ->
+                        output.write(settingsBytes)
+                    }
+                }
+                if (hasDb) {
+                    val dbPath = database.openHelper.writableDatabase.path!!
+                    runBlocking(Dispatchers.IO) {
+                        database.checkpoint()
+                    }
+                    database.close()
+                    // Drop stale WAL/SHM so SQLite doesn't replay old journal over the restored file.
+                    File("$dbPath-wal").delete()
+                    File("$dbPath-shm").delete()
+                    FileInputStream(tempDbFile).use { input ->
+                        FileOutputStream(dbPath).use { output ->
+                            input.copyTo(output)
+                        }
+                    }
+                }
+            } finally {
+                tempDbFile.delete()
+                File("${tempDbFile.path}-wal").delete()
+                File("${tempDbFile.path}-shm").delete()
+                File("${tempDbFile.path}-journal").delete()
             }
+
             context.stopService(Intent(context, MusicService::class.java))
             context.filesDir.resolve(PERSISTENT_QUEUE_FILE).delete()
             context.startActivity(Intent(context, MainActivity::class.java))
             exitProcess(0)
-        }.onFailure {
-            reportException(it)
-            Toast.makeText(context, R.string.restore_failed, Toast.LENGTH_SHORT).show()
+        }.onFailure { throwable ->
+            reportException(
+                if (throwable is BackupNewerException)
+                    Exception("Restore aborted: backup is from a newer app version", throwable)
+                else throwable
+            )
+            val messageRes = when (throwable) {
+                is BackupNewerException -> R.string.restore_backup_newer_version
+                else -> R.string.restore_failed
+            }
+            Toast.makeText(context, messageRes, Toast.LENGTH_LONG).show()
         }
     }
+
+    /**
+     * Opens the restored database file in an isolated Room instance, forcing Room to run its
+     * migrations up to the current schema version. Throws if no valid migration path exists.
+     * Uses TRUNCATE journal mode so the whole database stays in a single self-contained file
+     * that can then be copied into place.
+     */
+    private fun migrateBackupDatabase(context: Context, dbFile: File) {
+        File("${dbFile.path}-wal").delete()
+        File("${dbFile.path}-shm").delete()
+        File("${dbFile.path}-journal").delete()
+        val validationDb = InternalDatabase.databaseBuilder(context, dbFile.absolutePath)
+            .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
+            .build()
+        try {
+            // Accessing the writable database triggers open + migration (or throws).
+            validationDb.openHelper.writableDatabase
+        } finally {
+            validationDb.close()
+        }
+    }
+
+    private fun parseDbVersion(content: String): Int? =
+        content.lineSequence()
+            .mapNotNull { line ->
+                val parts = line.split("=", limit = 2)
+                if (parts.size == 2 && parts[0].trim() == KEY_DB_VERSION) {
+                    parts[1].trim().toIntOrNull()
+                } else null
+            }
+            .firstOrNull()
+
+    private class BackupNewerException : Exception()
+
     companion object {
         const val SETTINGS_FILENAME = "settings.preferences_pb"
+        const val METADATA_FILENAME = "metadata.txt"
+        private const val KEY_DB_VERSION = "db_version"
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -520,6 +520,7 @@
     <string name="backup_create_success">Backup created successfully</string>
     <string name="backup_create_failed">Couldn\'t create backup</string>
     <string name="restore_failed">Failed to restore backup</string>
+    <string name="restore_backup_newer_version">This backup was created with a newer version of the app. Update the app before restoring it.</string>
 
     <string name="discord_integration">Discord Integration</string>
     <string name="discord_information">Muzza uses the KizzyRPC library to set your Discord account\'s status. This involves using the Discord Gateway connection, which may be considered a violation of Discord\'s TOS. However, there are no known cases of user accounts being suspended for this reason. Use at your own risk.\n\nMuzza will only extract your token, and everything else is stored locally.</string>


### PR DESCRIPTION
## Summary
Restoring a backup created by an older app version crashed the app on startup, forcing users to clear app data (losing the imported backup entirely). This PR fixes the root cause in the migration chain and makes the restore flow fail-safe.

**Verified on a physical device:** restoring a real **v13** backup now migrates cleanly all the way to **v24** with no crash and the data intact.

## Root causes
1. **Redundant manual migrations shadowing the auto-migrations.** Hand-written migrations for `19->24` were added alongside the generated auto-migrations. Room lets a manually added migration override the auto-migration for the same version pair, and the hand-written `19->20` only added `isVideoSong` while skipping the column deletions the real `Migration19To20` performs. That left stale columns (`date`, `dateModified`, `likedDate`, `year`, ...) behind, so the final schema failed Room's validation.
2. **Premature `lyrics.provider` column.** `Migration19To20.onPostMigrate` added `lyrics.provider`, but per the exported schemas that column is first introduced in v21. Adding it early made the `20->21` auto-migration crash with `duplicate column name: provider`.
3. **Blind file swap on restore.** `restore()` overwrote the live `song.db` and called `exitProcess(0)`, trusting Room to migrate on next launch. Any migration failure became a permanent startup crash-loop whose only escape was clearing app data.

## Changes
- **Repaired migration chain** (`MusicDatabase.kt`): dropped the redundant manual `19->24` migrations and rely solely on the compile-verified auto-migrations; removed the premature `lyrics.provider` add from `Migration19To20`.
- **Validate-then-commit restore** (`BackupRestoreViewModel.kt`): the backup is extracted to a temp file and migrated to the current schema in an isolated Room instance *before* anything live is touched. If migration fails, the existing data is left intact and a toast is shown instead of crash-looping.
- **Self-describing backups**: new backups embed a `metadata.txt` entry recording the DB schema version, and a backup from a newer app version is rejected up-front with a clear message. Older app versions safely ignore the unknown entry, so new backups stay restorable by them.
- **Shared DB builder** for the live and validation instances so a backup is always migrated through the exact same path the app itself uses.
- **Safety net**: `fallbackToDestructiveMigrationOnDowngrade` so a downgrade can never permanently brick the app.
- Also deletes stale `-wal`/`-shm` sidecar files during the swap to avoid WAL replay corruption.

## Testing
- `./gradlew :app:assembleFossDebug` -> BUILD SUCCESSFUL.
- Installed the `foss` debug APK on a device (Galaxy S21 Ultra, Android 15) and restored a real v13 backup: migrates 13 -> 24 cleanly, no crash, data present.
- Note: the `full` flavor was not built locally as it requires a `google-services.json` not present in the repo; all changed files are flavor-independent.