### PR TITLE
Perf: make Library section counts instant and cut download-time jank

### DIFF
--- a/app/src/main/java/com/maloy/muzza/db/DatabaseDao.kt
+++ b/app/src/main/java/com/maloy/muzza/db/DatabaseDao.kt
@@ -353,6 +353,14 @@ interface DatabaseDao {
     suspend fun getSongsByIds(songIds: List<String>): List<Song>
 
     @Transaction
+    @Query("SELECT * FROM song WHERE id IN (:songIds)")
+    fun songsByIdsFlow(songIds: List<String>): Flow<List<Song>>
+
+    @Transaction
+    @Query("SELECT * FROM song WHERE liked OR inLibrary IS NOT NULL")
+    fun likedOrLibrarySongs(): Flow<List<Song>>
+
+    @Transaction
     @Query("SELECT * FROM song WHERE liked AND dateDownload IS NULL")
     fun likedSongsNotDownloaded(): Flow<List<Song>>
 

--- a/app/src/main/java/com/maloy/muzza/db/DatabaseDao.kt
+++ b/app/src/main/java/com/maloy/muzza/db/DatabaseDao.kt
@@ -118,6 +118,12 @@ interface DatabaseDao {
     @Query("SELECT COUNT(1) FROM song WHERE liked")
     fun likedSongsCount(): Flow<Int>
 
+    @Query("SELECT COUNT(1) FROM song WHERE inLibrary")
+    fun librarySongsCount(): Flow<Int>
+
+    @Query("SELECT COUNT(1) FROM song WHERE isLocal")
+    fun localSongsCount(): Flow<Int>
+
     @Transaction
     @Query("SELECT * FROM song WHERE isLocal ORDER BY rowId")
     fun localSongsByRowIdAsc(): Flow<List<Song>>

--- a/app/src/main/java/com/maloy/muzza/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/java/com/maloy/muzza/ui/screens/library/LibraryMixScreen.kt
@@ -144,6 +144,9 @@ fun LibraryMixScreen(
         }
 
     val likedSongs by viewModel.likedSongs.collectAsState()
+    val likedSongsCount by viewModel.likedSongsCount.collectAsState()
+    val librarySongsCount by viewModel.librarySongsCount.collectAsState()
+    val localSongsCount by viewModel.localSongsCount.collectAsState()
     val downloadSongs by viewModel.downloadSongs.collectAsState(initial = null)
     val topSongs by viewModel.topSongs.collectAsState(initial = null)
     val localSongs by viewModel.localSongs.collectAsState()
@@ -203,7 +206,7 @@ fun LibraryMixScreen(
             id = "local",
             name = stringResource(R.string.local)
         ),
-        songCount = localSongs?.size ?: 0,
+        songCount = localSongsCount ?: 0,
         songThumbnails = emptyList()
     )
 
@@ -214,7 +217,7 @@ fun LibraryMixScreen(
                 stringResource(R.string.liked)
             }
         ),
-        songCount = likedSongs?.size ?: 0,
+        songCount = likedSongsCount ?: 0,
         songThumbnails = emptyList()
     )
 
@@ -223,7 +226,7 @@ fun LibraryMixScreen(
             id = "libraryMusic",
             name = stringResource(R.string.songs_from_library)
         ),
-        songCount = librarySongs?.size ?: 0,
+        songCount = librarySongsCount ?: 0,
         songThumbnails = emptyList()
     )
 
@@ -422,8 +425,8 @@ fun LibraryMixScreen(
                         Text(
                             text = pluralStringResource(
                                 R.plurals.n_song,
-                                likedSongs?.size ?: 0,
-                                likedSongs?.size ?: 0
+                                likedSongsCount ?: 0,
+                                likedSongsCount ?: 0
                             ),
                             style = MaterialTheme.typography.bodyMedium
                         )
@@ -641,8 +644,8 @@ fun LibraryMixScreen(
                                     Text(
                                         text = pluralStringResource(
                                             R.plurals.n_song,
-                                            librarySongs?.size ?: 0,
-                                            librarySongs?.size ?: 0
+                                            librarySongsCount ?: 0,
+                                            librarySongsCount ?: 0
                                         ),
                                         style = MaterialTheme.typography.bodySmall
                                     )

--- a/app/src/main/java/com/maloy/muzza/viewmodels/LibraryViewModels.kt
+++ b/app/src/main/java/com/maloy/muzza/viewmodels/LibraryViewModels.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
@@ -447,25 +448,48 @@ class LibraryMixViewModel @Inject constructor(
     val likedSongs = database.likedSongs(SongSortType.CREATE_DATE, true)
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
+    // Section counts are read straight from SQL COUNT(...) instead of materializing the full
+    // relation-joined song lists just to call .size on them. This lets the cards show the
+    // correct numbers immediately (instead of "0 songs" until the whole list loads) and avoids
+    // heavy work on every library change.
+    val likedSongsCount = database.likedSongsCount()
+        .stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+    val librarySongsCount = database.librarySongsCount()
+        .stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+    val localSongsCount = database.localSongsCount()
+        .stateIn(viewModelScope, SharingStarted.Lazily, null)
+
     val librarySongs = database.librarySongs(SongSortType.CREATE_DATE, true)
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
     val libraryLikedLibrarySongs = database.allSongs()
         .map { songs -> songs.filter { it.song.liked || it.song.inLibrary != null } }
+        // Only emit when the actual set of songs changes, not on every metadata/date update.
+        // Prevents the (network + DB write) effect that observes this from re-firing constantly
+        // while songs are being downloaded/cached.
+        .distinctUntilChangedBy { songs -> songs.map { it.song.id } }
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
     val localSongs = database.localSongs(SongSortType.CREATE_DATE, true)
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
     val downloadSongs =
-        downloadUtil.downloads.flatMapLatest { downloads ->
-            database.allSongs()
-                .flowOn(Dispatchers.IO)
-                .map { songs ->
-                    songs.filter {
-                        downloads[it.id]?.state == Download.STATE_COMPLETED
+        downloadUtil.downloads
+            // Collapse the constant DownloadManager progress churn down to only the set of
+            // completed ids; the expensive full-table query below then re-runs only when a
+            // download actually completes, not on every progress tick.
+            .map { downloads ->
+                downloads.filterValues { it.state == Download.STATE_COMPLETED }.keys
+            }
+            .distinctUntilChanged()
+            .flatMapLatest { completedIds ->
+                database.allSongs()
+                    .flowOn(Dispatchers.IO)
+                    .map { songs ->
+                        songs.filter { it.id in completedIds }
                     }
-                }
-        }
+            }
     val topSongs = database.mostPlayedSongs(0, 100)
 }

--- a/app/src/main/java/com/maloy/muzza/viewmodels/LibraryViewModels.kt
+++ b/app/src/main/java/com/maloy/muzza/viewmodels/LibraryViewModels.kt
@@ -60,6 +60,7 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -464,8 +465,7 @@ class LibraryMixViewModel @Inject constructor(
     val librarySongs = database.librarySongs(SongSortType.CREATE_DATE, true)
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
-    val libraryLikedLibrarySongs = database.allSongs()
-        .map { songs -> songs.filter { it.song.liked || it.song.inLibrary != null } }
+    val libraryLikedLibrarySongs = database.likedOrLibrarySongs()
         // Only emit when the actual set of songs changes, not on every metadata/date update.
         // Prevents the (network + DB write) effect that observes this from re-firing constantly
         // while songs are being downloaded/cached.
@@ -478,18 +478,21 @@ class LibraryMixViewModel @Inject constructor(
     val downloadSongs =
         downloadUtil.downloads
             // Collapse the constant DownloadManager progress churn down to only the set of
-            // completed ids; the expensive full-table query below then re-runs only when a
-            // download actually completes, not on every progress tick.
+            // completed ids; the query below then re-runs only when a download actually
+            // completes, not on every progress tick.
             .map { downloads ->
                 downloads.filterValues { it.state == Download.STATE_COMPLETED }.keys
             }
             .distinctUntilChanged()
             .flatMapLatest { completedIds ->
-                database.allSongs()
-                    .flowOn(Dispatchers.IO)
-                    .map { songs ->
-                        songs.filter { it.id in completedIds }
-                    }
+                if (completedIds.isEmpty()) {
+                    flowOf(emptyList())
+                } else {
+                    // Fetch only the completed songs by id instead of loading the entire
+                    // song table and filtering in memory.
+                    database.songsByIdsFlow(completedIds.toList())
+                        .flowOn(Dispatchers.IO)
+                }
             }
     val topSongs = database.mostPlayedSongs(0, 100)
 }


### PR DESCRIPTION
## Summary
Opening the Library screen with a large library — especially while a big playlist is downloading or a YouTube sync is running — froze the UI, spiked CPU, and showed "Liked music - 0 songs" for a long time before the correct counts appeared. This PR removes the causes. Verified on a physical device with a **10,854-song** library.

## Root causes
1. **Two flows loaded the entire song table.** `libraryLikedLibrarySongs` and `downloadSongs` called `allSongs()` (`SELECT * FROM song`) and materialized **every** row with its artist/album/format `@Relation` joins, then filtered down to a few hundred in Kotlin. On a 10k-song library this is very expensive, and it re-ran on every write from sync/downloads. Profiling showed **4 SQLite IO threads pinned at ~50% each**, the main thread at ~52%, and a **>20 MB WAL**.
2. **Counts were `.size` of those full lists.** Each section card bound its count to `likedSongs?.size` / `librarySongs?.size` / `localSongs?.size`, and those flows start at `null` — so the cards read **0** until the whole (large) list finished materializing. A `SELECT COUNT(1)` query already existed but was unused here.
3. **Download progress churn re-triggered the full-table queries.** `downloadUtil.downloads` (a `StateFlow<Map>`) updates on every `onDownloadChanged` (queued → progress → completed, ×N, 3 parallel), and each tick cancelled/re-ran the `allSongs()`-based flows.

## Changes
- **`DatabaseDao`**: add `librarySongsCount()` / `localSongsCount()` `COUNT(1)` flows (liked already existed); add `likedOrLibrarySongs()` (`WHERE liked OR inLibrary IS NOT NULL`) and `songsByIdsFlow()`.
- **`LibraryMixViewModel`**:
  - expose the COUNT flows for the section cards;
  - replace `allSongs().filter { liked || inLibrary }` with the targeted `likedOrLibrarySongs()` query (~hundreds of rows instead of all 10k);
  - make `downloadSongs` fetch only the completed ids via `songsByIdsFlow()` instead of loading the whole table, and collapse the download progress churn with `distinctUntilChanged` on the completed-id set;
  - only re-emit `libraryLikedLibrarySongs` when the set of song ids changes (`distinctUntilChangedBy`), so the network+DB sync effect that observes it stops re-firing on metadata-only updates.
- **`LibraryMixScreen`**: bind the Liked/Library/Local card counts (and the liked header text) to the COUNT flows instead of `.size`.

## On-device results (10,854-song library)
| Metric | Before | After |
|---|---|---|
| SQLite `arch_disk_io` threads | 4 threads at ~46-59% each | idle (~0%) |
| Main thread | ~52% | not hot |
| WAL file | ~22 MB | 0 bytes (checkpointed) |

Section counts now render immediately and the Library stays responsive during sync/downloads.

## Testing
- `./gradlew :app:compileFossDebugKotlin` / `assembleFossDebug` -> BUILD SUCCESSFUL (only pre-existing unrelated deprecation warnings).
- Installed the `foss` debug APK on a device (Galaxy S21 Ultra, Android 15) and profiled the Library screen before/after (table above).
- Note: the `full` flavor was not built locally as it requires a `google-services.json` not present in the repo; all changed files are flavor-independent.

## Possible follow-up (not in this PR)
`LibraryMixViewModel` also runs a `while (true) { … delay(1000) }` poller that touches the DB every second; it's quiet now but could be throttled/event-driven in a separate change.